### PR TITLE
Implement a quit command.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ repository = "https://github.com/jrvanwhy/text-editor"
 
 [dependencies.ratatui]
 default-features = false
-features = ["crossterm"]
+features = ["crossterm", "scrolling-regions"]
 # TODO: When updated beyond 0.29.0, check if "layout-cache" has been enabled.
 version = "0.29.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 Ryan Van Why
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Mode, State, prompt};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+pub fn on_key(state: &mut State, key_event: KeyEvent) {
+	match key_event.code {
+		KeyCode::Char(':') => prompt::start(state),
+		_ => {}
+	}
+}
+
+pub fn on_paste(_state: &mut State, _paste: String) {}
+
+pub fn start(state: &mut State) {
+	state.mode = Mode::Command;
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,36 @@
+// Copyright 2025 Ryan Van Why
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ratatui::crossterm;
+use ratatui::crossterm::event::{self, KeyEvent};
+
+pub enum Event {
+	Key(KeyEvent),
+	Paste(String),
+	Resize,
+}
+
+pub fn next() -> Event {
+	loop {
+		use crossterm::event::Event as CrosstermEvent;
+		return match event::read().expect("stdin event read failed") {
+			CrosstermEvent::FocusGained | CrosstermEvent::FocusLost | CrosstermEvent::Mouse(_) => {
+				continue;
+			}
+			CrosstermEvent::Key(key_event) => Event::Key(key_event),
+			CrosstermEvent::Paste(string) => Event::Paste(string.replace('\r', "\n")),
+			CrosstermEvent::Resize(_, _) => Event::Resize,
+		};
+	}
+}

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 Ryan Van Why
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Mode, State, command};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+pub type Prompt = String;
+
+pub fn on_key(state: &mut State, key_event: KeyEvent) {
+	match key_event.code {
+		KeyCode::Backspace => {
+			if state.prompt.pop().is_none() {
+				state.message = String::new();
+				command::start(state);
+			} else {
+				update_message(state);
+			}
+		}
+		KeyCode::Enter => execute_cmd(state),
+		KeyCode::Esc => {
+			state.message = String::new();
+			command::start(state);
+		}
+		KeyCode::Char(c) => {
+			state.prompt.push(c);
+			update_message(state);
+		}
+		_ => {}
+	}
+}
+
+pub fn on_paste(_state: &mut State, _paste: String) {}
+
+pub fn start(state: &mut State) {
+	state.mode = Mode::Prompt;
+	state.prompt = String::new();
+	update_message(state);
+}
+
+// -----------------------------------------------------------------------------
+// Implementation details below.
+// -----------------------------------------------------------------------------
+
+fn execute_cmd(state: &mut State) {
+	match &*state.prompt {
+		"q" | "q!" => state.exit = true,
+		_ => {}
+	}
+	command::start(state);
+}
+
+fn update_message(state: &mut State) {
+	state.message = format!(":{}", state.prompt);
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,37 @@
+// Copyright 2025 Ryan Van Why
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Mode, State};
+use ratatui::Frame;
+use ratatui::{
+	layout::{Constraint, Layout},
+	text::Line,
+};
+
+pub fn render(frame: &mut Frame, state: &mut State) {
+	let [_tabs, _textarea, statusline] =
+		Layout::vertical([Constraint::Length(1), Constraint::Fill(1), Constraint::Length(1)])
+			.areas(frame.area());
+	let message = Line::from(&*state.message);
+	let message_width: u16 = message.width().try_into().unwrap();
+	frame.render_widget(message, statusline);
+	state.cursor_position = match state.mode {
+		Mode::Command => None,
+		Mode::Prompt => {
+			let mut pos = statusline.as_position();
+			pos.x += message_width;
+			Some(pos)
+		}
+	};
+}


### PR DESCRIPTION
This replaces the "exit if the q key is pressed" temporary logic with a mode system. The modes do different a bit from vim: this editor has "command" mode (where pressing individual keys or short sequences triggers behaviors) and "prompt" mode (where you type a command line). vim calls these both "command".

For now, only the q and q! commands are implemented (and q doesn't check if the current file is saved, because that concept does not exist yet).